### PR TITLE
[fix] : call the method isEmpty instead of checking the attribute length that does not exist

### DIFF
--- a/src/java/nanomsg/pubsub/SubSocket.java
+++ b/src/java/nanomsg/pubsub/SubSocket.java
@@ -23,7 +23,7 @@ public class SubSocket extends Socket implements ISubscriptionSocket {
 
   @Override
   public void subscribe(final String topic) throws IOException {
-    if(topic.length == 0)
+    if(topic.isEmpty())
     {
         subscribe(new byte[1], 0);
     }


### PR DESCRIPTION
…

The compilation fails with the error below when using OpenJDK.

```
~/jnanomsg/src/java/nanomsg/pubsub/SubSocket.java:26:
error: cannot find symbol
    if(topic.length == 0)
               ^
symbol:   variable length
location: variable topic of type String
1 error
Compilation of Java sources(lein javac) failed.

~/jnanomsg(branch:bug/javac*) » java -version
openjdk version "1.8.0_51"
OpenJDK Runtime Environment (build 1.8.0_51-b16)
OpenJDK 64-Bit Server VM (build 25.51-b03, mixed mode)
```