### PR TITLE
Refactored Nanomsg constants to Enums

### DIFF
--- a/src/java/nanomsg/Device.java
+++ b/src/java/nanomsg/Device.java
@@ -1,9 +1,5 @@
 package nanomsg;
 
-import java.lang.Runnable;
-import nanomsg.NativeLibrary;
-
-
 public class Device implements Runnable {
   private final int sourceSocket;
   private final int destSocket;

--- a/src/java/nanomsg/Nanomsg.java
+++ b/src/java/nanomsg/Nanomsg.java
@@ -1,12 +1,10 @@
 package nanomsg;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 
-import nanomsg.NativeLibrary;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public final class Nanomsg {
@@ -45,45 +43,75 @@ public final class Nanomsg {
     return result;
   }
 
-  public static final Map<String, Integer> symbols = Nanomsg.getSymbols();
+  public static final Map<String, Integer> nn_symbols = Nanomsg.getSymbols();
 
-  public static class constants {
-    public static final int ECONNREFUSED = Nanomsg.symbols.get("ECONNREFUSED");
-    public static final int EAFNOSUPPORT = Nanomsg.symbols.get("EAFNOSUPPORT");
-    public static final int ETERM = Nanomsg.symbols.get("ETERM");
-    public static final int EFSM = Nanomsg.symbols.get("EFSM");
-    public static final int EAGAIN = Nanomsg.symbols.get("EAGAIN");
-    public static final int NN_DONTWAIT = Nanomsg.symbols.get("NN_DONTWAIT");
-    public static final int AF_SP = Nanomsg.symbols.get("AF_SP");
-    public static final int AF_SP_RAW = Nanomsg.symbols.get("AF_SP_RAW");
+  public enum Domain {
+    AF_SP,
+    AF_SP_RAW;
 
-    public static final int NN_SOL_SOCKET = Nanomsg.symbols.get("NN_SOL_SOCKET");
-    public static final int NN_SNDFD = Nanomsg.symbols.get("NN_SNDFD");
-    public static final int NN_RCVFD = Nanomsg.symbols.get("NN_RCVFD");
-    public static final int NN_SNDTIMEO = Nanomsg.symbols.get("NN_SNDTIMEO");
-    public static final int NN_RCVTIMEO = Nanomsg.symbols.get("NN_RCVTIMEO");
+    public Integer value() {
+      return nn_symbols.get(name());
+    }
+  }
 
-    public static final int NN_MSG = -1;
+  public enum SocketType {
 
     /* PubSub */
-    public static final int NN_PUB = Nanomsg.symbols.get("NN_PUB");
-    public static final int NN_SUB = Nanomsg.symbols.get("NN_SUB");
-    public static final int NN_SUB_SUBSCRIBE = Nanomsg.symbols.get("NN_SUB_SUBSCRIBE");
-    public static final int NN_SUB_UNSUBSCRIBE = Nanomsg.symbols.get("NN_SUB_UNSUBSCRIBE");
+    NN_PUB,
+    NN_SUB,
 
     /* ReqRep */
-    public static final int NN_REQ = Nanomsg.symbols.get("NN_REQ");
-    public static final int NN_REP = Nanomsg.symbols.get("NN_REP");
-    public static final int NN_REQ_RESEND_IVL = Nanomsg.symbols.get("NN_REQ_RESEND_IVL");
-
-    /* Pair */
-    public static final int NN_PAIR = Nanomsg.symbols.get("NN_PAIR");
+    NN_REQ,
+    NN_REP,
 
     /* Pipeline */
-    public static final int NN_PUSH = Nanomsg.symbols.get("NN_PUSH");
-    public static final int NN_PULL = Nanomsg.symbols.get("NN_PULL");
+    NN_PUSH,
+    NN_PULL,
 
     /* Bus */
-    public static final int NN_BUS = Nanomsg.symbols.get("NN_BUS");
+    NN_BUS,
+
+    /* Pair */
+    NN_PAIR;
+
+    public Integer value() {
+      return nn_symbols.get(name());
+    }
+  }
+
+  public enum SocketOption {
+    NN_SUB_UNSUBSCRIBE,
+    NN_REQ_RESEND_IVL,
+    NN_SUB_SUBSCRIBE,
+    NN_SNDTIMEO,
+    NN_SNDFD,
+    NN_RCVFD,
+    NN_RCVTIMEO;
+
+    public Integer value() {
+      return nn_symbols.get(name());
+    }
+  }
+
+  public enum MethodOption {
+    NN_SOL_SOCKET,
+    NN_MSG,
+    NN_DONTWAIT;
+
+    public Integer value() {
+      return name().equals("NN_MSG") ? -1 : nn_symbols.get(name());
+    }
+  }
+
+  public enum Error {
+    EAFNOSUPPORT,
+    ETERM,
+    EFSM,
+    EAGAIN,
+    ECONNREFUSED;
+
+    public Integer value() {
+      return nn_symbols.get(name());
+    }
   }
 }

--- a/src/java/nanomsg/async/AsyncSocket.java
+++ b/src/java/nanomsg/async/AsyncSocket.java
@@ -1,16 +1,14 @@
 package nanomsg.async;
 
-import java.nio.ByteBuffer;
-
-import nanomsg.Nanomsg;
 import nanomsg.Socket;
-import nanomsg.exceptions.IOException;
-import nanomsg.exceptions.EAgainException;
-import nanomsg.async.IAsyncCallback;
-import nanomsg.async.IAsyncRunnable;
-import nanomsg.async.IAsyncScheduler;
 import nanomsg.async.impl.EPollScheduler;
 import nanomsg.async.impl.ThreadPoolScheduler;
+import nanomsg.exceptions.EAgainException;
+import nanomsg.exceptions.IOException;
+
+import java.nio.ByteBuffer;
+
+import static nanomsg.Nanomsg.Error.EAGAIN;
 
 /**
  * Experimental socket proxy that enables async way to
@@ -76,7 +74,7 @@ public class AsyncSocket {
             socket.send(data);
             callback.success(true);
           } catch (IOException e) {
-            if (e.getErrno() == Nanomsg.constants.EAGAIN) {
+            if (e.getErrno() == EAGAIN.value()) {
               throw new EAgainException(e);
             } else {
               callback.fail(e);
@@ -106,7 +104,7 @@ public class AsyncSocket {
             final String received = socket.recvString();
             callback.success(received);
           } catch (IOException e) {
-            if (e.getErrno() == Nanomsg.constants.EAGAIN) {
+            if (e.getErrno() == EAGAIN.value()) {
               throw e;
             } else {
               callback.fail(e);
@@ -137,7 +135,7 @@ public class AsyncSocket {
             socket.send(data);
             callback.success(true);
           } catch (IOException e) {
-            if (e.getErrno() == Nanomsg.constants.EAGAIN) {
+            if (e.getErrno() == EAGAIN.value()) {
               throw new EAgainException(e);
             } else {
               callback.fail(e);
@@ -167,7 +165,7 @@ public class AsyncSocket {
             final byte[] received = socket.recvBytes();
             callback.success(received);
           } catch (IOException e) {
-            if (e.getErrno() == Nanomsg.constants.EAGAIN) {
+            if (e.getErrno() == EAGAIN.value()) {
               throw new EAgainException(e);
             } else {
               callback.fail(e);
@@ -198,7 +196,7 @@ public class AsyncSocket {
             socket.send(data);
             callback.success(true);
           } catch (IOException e) {
-            if (e.getErrno() == Nanomsg.constants.EAGAIN) {
+            if (e.getErrno() == EAGAIN.value()) {
               throw new EAgainException(e);
             } else {
               callback.fail(e);
@@ -228,7 +226,7 @@ public class AsyncSocket {
             final ByteBuffer received = socket.recv();
             callback.success(received);
           } catch (IOException e) {
-            if (e.getErrno() == Nanomsg.constants.EAGAIN) {
+            if (e.getErrno() == EAGAIN.value()) {
               throw new EAgainException(e);
             } else {
               callback.fail(e);

--- a/src/java/nanomsg/async/IAsyncScheduler.java
+++ b/src/java/nanomsg/async/IAsyncScheduler.java
@@ -1,7 +1,6 @@
 package nanomsg.async;
 
 import nanomsg.Socket;
-import nanomsg.async.AsyncOperation;
 
 
 public interface IAsyncScheduler {

--- a/src/java/nanomsg/async/impl/EPollScheduler.java
+++ b/src/java/nanomsg/async/impl/EPollScheduler.java
@@ -1,29 +1,18 @@
 package nanomsg.async.impl;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import java.util.Queue;
-import java.util.Map;
-import java.util.LinkedList;
-import java.lang.Thread;
-
 import com.sun.jna.Memory;
-import com.sun.jna.Pointer;
-import com.sun.jna.Native;
-import com.sun.jna.ptr.PointerByReference;
-
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
+import nanomsg.async.AsyncOperation;
 import nanomsg.async.IAsyncRunnable;
 import nanomsg.async.IAsyncScheduler;
-import nanomsg.async.AsyncOperation;
 import nanomsg.async.impl.epoll.Epoll;
-
-import nanomsg.exceptions.EAgainException;
 import nanomsg.exceptions.IOException;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static nanomsg.Nanomsg.Error.EAGAIN;
 
 
 public class EPollScheduler implements Runnable, IAsyncScheduler {
@@ -96,7 +85,7 @@ public class EPollScheduler implements Runnable, IAsyncScheduler {
         runnable.run();
       } catch (IOException e) {
         final int errno = e.getErrno();
-        if (errno == Nanomsg.constants.EAGAIN) {
+        if (errno == EAGAIN.value()) {
           System.out.println("EAGAIN error for fd=" + fd);
           this.register(fd, event.events, runnable);
         } else {

--- a/src/java/nanomsg/async/impl/ThreadPoolScheduler.java
+++ b/src/java/nanomsg/async/impl/ThreadPoolScheduler.java
@@ -1,19 +1,15 @@
 package nanomsg.async.impl;
 
-import java.util.concurrent.ConcurrentLinkedQueue;
+import nanomsg.Socket;
+import nanomsg.async.AsyncOperation;
+import nanomsg.async.IAsyncRunnable;
+import nanomsg.async.IAsyncScheduler;
+import nanomsg.exceptions.IOException;
+
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import java.util.Queue;
-import java.util.LinkedList;
-import java.lang.Thread;
-
-import nanomsg.Nanomsg;
-import nanomsg.Socket;
-import nanomsg.async.IAsyncRunnable;
-import nanomsg.async.IAsyncScheduler;
-import nanomsg.async.AsyncOperation;
-import nanomsg.exceptions.IOException;
+import static nanomsg.Nanomsg.Error.EAGAIN;
 
 
 public class ThreadPoolScheduler implements Runnable, IAsyncScheduler {
@@ -67,7 +63,7 @@ public class ThreadPoolScheduler implements Runnable, IAsyncScheduler {
           handler.run();
         } catch (IOException e) {
           final int errno = e.getErrno();
-          if (errno == Nanomsg.constants.EAGAIN) {
+          if (errno == EAGAIN.value()) {
             queue.put(handler);
           }
         }

--- a/src/java/nanomsg/async/impl/epoll/Epoll.java
+++ b/src/java/nanomsg/async/impl/epoll/Epoll.java
@@ -20,12 +20,10 @@
 
 package nanomsg.async.impl.epoll;
 
-import com.sun.jna.Union;
-import com.sun.jna.Pointer;
-import com.sun.jna.ptr.PointerByReference;
-import com.sun.jna.Memory;
-import com.sun.jna.Structure;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.Union;
 
 import java.util.Arrays;
 import java.util.List;
@@ -155,7 +153,7 @@ public class Epoll {
                 data.setType(Pointer.class);
             }
 
-            public ByReference oneshot() {
+            public Structure.ByReference oneshot() {
                 this.events = events | EPOLLONESHOT;
                 return this;
             }

--- a/src/java/nanomsg/bus/BusSocket.java
+++ b/src/java/nanomsg/bus/BusSocket.java
@@ -1,15 +1,16 @@
 package nanomsg.bus;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
 
 
 public class BusSocket extends Socket {
-  public BusSocket(int domain) {
-    super(domain, Nanomsg.constants.NN_BUS);
+  public BusSocket(Domain domain) {
+    super(domain, SocketType.NN_BUS);
   }
 
   public BusSocket() {
-    this(Nanomsg.constants.AF_SP);
+    this(Domain.AF_SP);
   }
 }

--- a/src/java/nanomsg/pair/PairSocket.java
+++ b/src/java/nanomsg/pair/PairSocket.java
@@ -1,15 +1,16 @@
 package nanomsg.pair;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
 
 
 public class PairSocket extends Socket {
-  public PairSocket(int domain) {
-    super(domain, Nanomsg.constants.NN_PAIR);
+  public PairSocket(Domain domain) {
+    super(domain, SocketType.NN_PAIR);
   }
 
   public PairSocket() {
-    this(Nanomsg.constants.AF_SP);
+    this(Domain.AF_SP);
   }
 }

--- a/src/java/nanomsg/pipeline/PullSocket.java
+++ b/src/java/nanomsg/pipeline/PullSocket.java
@@ -1,15 +1,15 @@
 package nanomsg.pipeline;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
-
 
 public class PullSocket extends Socket {
-  public PullSocket(int domain) {
-    super(domain, Nanomsg.constants.NN_PULL);
+  public PullSocket(Domain domain) {
+    super(domain, SocketType.NN_PULL);
   }
 
   public PullSocket() {
-    this(Nanomsg.constants.AF_SP);
+    this(Domain.AF_SP);
   }
 }

--- a/src/java/nanomsg/pipeline/PushSocket.java
+++ b/src/java/nanomsg/pipeline/PushSocket.java
@@ -1,15 +1,16 @@
 package nanomsg.pipeline;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
 
 
 public class PushSocket extends Socket {
-  public PushSocket(int domain) {
-    super(domain, Nanomsg.constants.NN_PUSH);
+  public PushSocket(Domain domain) {
+    super(domain, SocketType.NN_PUSH);
   }
 
   public PushSocket() {
-    this(Nanomsg.constants.AF_SP);
+    this(Domain.AF_SP);
   }
 }

--- a/src/java/nanomsg/pubsub/PubSocket.java
+++ b/src/java/nanomsg/pubsub/PubSocket.java
@@ -1,14 +1,15 @@
 package nanomsg.pubsub;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
 
 public class PubSocket extends Socket {
-  public PubSocket(int domain) {
-    super(domain, Nanomsg.constants.NN_PUB);
+  public PubSocket(Domain domain) {
+    super(domain, SocketType.NN_PUB);
   }
 
   public PubSocket() {
-    this(Nanomsg.constants.AF_SP);
+    this(Domain.AF_SP);
   }
 }

--- a/src/java/nanomsg/pubsub/SubSocket.java
+++ b/src/java/nanomsg/pubsub/SubSocket.java
@@ -1,24 +1,24 @@
 package nanomsg.pubsub;
 
 import com.sun.jna.Memory;
-import com.sun.jna.Native;
-import com.sun.jna.Pointer;
 import nanomsg.Nanomsg;
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketOption;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.NativeLibrary;
 import nanomsg.Socket;
 import nanomsg.exceptions.IOException;
 
 import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 
 
 public class SubSocket extends Socket implements ISubscriptionSocket {
-  public SubSocket(int domain) {
-    super(domain, Nanomsg.constants.NN_SUB);
+  public SubSocket(Domain domain) {
+    super(domain, Nanomsg.SocketType.NN_SUB);
   }
 
   public SubSocket() {
-    this(Nanomsg.constants.AF_SP);
+    this(Domain.AF_SP);
   }
 
   @Override
@@ -44,9 +44,9 @@ public class SubSocket extends Socket implements ISubscriptionSocket {
     final Memory mem = new Memory(patternBytes.length);
     mem.write(0, patternBytes, 0, patternBytes.length);
           
-    NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SUB, Nanomsg.constants.NN_SUB_SUBSCRIBE,
+    NativeLibrary.nn_setsockopt(socket, SocketType.NN_SUB.value(), SocketOption.NN_SUB_SUBSCRIBE.value(),
                                       mem, length);
-          // NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SUB, Nanomsg.constants.NN_SUB_SUBSCRIBE,
+          // NativeLibrary.nn_setsockopt(socket, NN_SUB.value(), NN_SUB_SUBSCRIBE.value(),
           // null, 0);
   }
     
@@ -72,7 +72,7 @@ public class SubSocket extends Socket implements ISubscriptionSocket {
     final Memory mem = new Memory(patternBytes.length);
     mem.write(0, patternBytes, 0, patternBytes.length);
 
-    NativeLibrary.nn_setsockopt(socket, Nanomsg.constants.NN_SUB, Nanomsg.constants.NN_SUB_UNSUBSCRIBE,
+    NativeLibrary.nn_setsockopt(socket, SocketType.NN_SUB.value(), SocketOption.NN_SUB_UNSUBSCRIBE.value(),
                                 mem, patternBytes.length);
   }
 }

--- a/src/java/nanomsg/reqrep/RepSocket.java
+++ b/src/java/nanomsg/reqrep/RepSocket.java
@@ -1,15 +1,16 @@
 package nanomsg.reqrep;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
 
 
 public class RepSocket extends Socket {
-    public RepSocket(int domain) {
-        super(domain, Nanomsg.constants.NN_REP);
-    }
+  public RepSocket(Domain domain) {
+    super(domain, SocketType.NN_REP);
+  }
 
-    public RepSocket() {
-        this(Nanomsg.constants.AF_SP);
-    }
+  public RepSocket() {
+    this(Domain.AF_SP);
+  }
 }

--- a/src/java/nanomsg/reqrep/ReqSocket.java
+++ b/src/java/nanomsg/reqrep/ReqSocket.java
@@ -1,15 +1,16 @@
 package nanomsg.reqrep;
 
+import nanomsg.Nanomsg.Domain;
+import nanomsg.Nanomsg.SocketType;
 import nanomsg.Socket;
-import nanomsg.Nanomsg;
 
 
 public class ReqSocket extends Socket {
-    public ReqSocket(int domain) {
-        super(domain, Nanomsg.constants.NN_REQ);
-    }
+  public ReqSocket(Domain domain) {
+    super(domain, SocketType.NN_REQ);
+  }
 
-    public ReqSocket() {
-        this(Nanomsg.constants.AF_SP);
-    }
+  public ReqSocket() {
+    this(Domain.AF_SP);
+  }
 }

--- a/src/test/nanomsg/NanomsgTest.java
+++ b/src/test/nanomsg/NanomsgTest.java
@@ -1,0 +1,19 @@
+package nanomsg;
+
+import nanomsg.Nanomsg.MethodOption;
+import nanomsg.Nanomsg.SocketType;
+import org.junit.Test;
+
+import static nanomsg.Nanomsg.nn_symbols;
+import static org.junit.Assert.assertEquals;
+
+public class NanomsgTest {
+
+  @Test
+  public void canGetSymbols() {
+
+    assertEquals(98, nn_symbols.size());
+    assertEquals(SocketType.NN_PUB.value(), nn_symbols.get("NN_PUB"));
+    assertEquals(MethodOption.NN_MSG.value(), new Integer(-1));
+  }
+}


### PR DESCRIPTION
Using `Enum` in order to deal with Object types instead of magic Integers. For example:

    public Socket(final Domain domain, final SocketType protocol) {
        ...
    }

Also added a single `JUnit` test for this change.