### PR TITLE
Reinsert previously removed nn_freemsg call to prevent memory leak

### DIFF
--- a/src/java/nanomsg/AbstractSocket.java
+++ b/src/java/nanomsg/AbstractSocket.java
@@ -130,6 +130,7 @@ public abstract class AbstractSocket implements Socket {
     final Pointer result = ptrBuff.getValue();
     final byte[] bytesResult = result.getByteArray(0, rc);
 
+    NativeLibrary.nn_freemsg(result);
     return bytesResult;
   }
 


### PR DESCRIPTION
In a previous commit (b33be1f7aa55d38f4a8d5e3f399f4ed878bbdfc3) a line that deallocated the message memory via a native call (`nn_freemsg`), was removed with the comment that the Java garbage collector would be expected to do that job.

However, the opposite seems to be the case, and Java cannot be expected to free the native memory for us.
Experimentally it has been found that memory was leaking because of this, and reintroduction of the `nn_freemsg` call stopped the leak.

For reference, the nanomsg documentation for `nn_recv` states:

> If the call is successful the user is responsible for deallocating the message using the nn_freemsg(3) function.
